### PR TITLE
Use container-fluid class to prevent inconsistent 'Next' placement

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -62,7 +62,7 @@
 
         <br />
         <div class="navbar navbar-default col-md-10 col-md-offset-1" role="navigation">
-            <div class="container">
+            <div class="container-fluid">
                 <ul class="nav navbar-nav navbar-left">
                     <li class="navbar-brand next-text"></li>
                 </ul>


### PR DESCRIPTION
First off thanks for making this! I'm loving it!

Noticed the 'Next' link for each lesson was, depending on screen size, displaying inconsistently or not at all:

![image](https://cloud.githubusercontent.com/assets/1479206/4967976/6876b8fc-682c-11e4-8881-63e425edc501.png) ![image](https://cloud.githubusercontent.com/assets/1479206/4967978/761b37a8-682c-11e4-8176-bc8a407796dc.png)

 ![image](https://cloud.githubusercontent.com/assets/1479206/4967983/829d39d6-682c-11e4-9e50-870e71a8f51d.png)

Using `container-fluid` resolves the issue nicely :smile: 
