### PR TITLE
Use $.animate on html instead of body so viewport is scrolled to top on navigation

### DIFF
--- a/site/src/app.js
+++ b/site/src/app.js
@@ -66,14 +66,13 @@ function updateNav(url) {
 
 function animateContent(content) {
   var $intro = $('.intro');
-  var $body = $('body');
+  var $html = $('html');
 
-  $intro.fadeOut(function() {
-    $intro.html(content || '').fadeIn(function() {
-    });
+  $html.animate({scrollTop: 0});
+  $intro.fadeOut( () => {
+    $intro.html(content || '').fadeIn();
   });
 
-  $body.animate({scrollTop: 0});
 }
 
 function mapPage(pageName, url) {


### PR DESCRIPTION
This looked like intended functionality that wasn't working for me (OSX, Chrome) but seemed like a solid idea. This has some funkiness to it, however, as it seems like `animateContent()` is invoked more than once on page load. I haven't been able to look into that yet though. The end result is a bit of flickering... may not be an improvement. What do you think?
