### PR TITLE
Catching and displaying the error from failed code execution

### DIFF
--- a/src/redux/actions.js
+++ b/src/redux/actions.js
@@ -27,7 +27,8 @@ export function executeCode(code, currentModule) {
 
         compile(code)
             .then(transpiled => execute(transpiled, moduleName))
-            .then(() => dispatch({type: action.EXECUTE_CODE_COMPLETE}));
+            .then(() => dispatch({type: action.EXECUTE_CODE_COMPLETE}))
+            .catch(e => { console.log(`[ERROR] ${e.toString()}`); });
     };
 };
 


### PR DESCRIPTION
I noticed that on the website, an error gives no feedback to the user. This is especially so when the default code is expected to give an error (http://learnharmony.org/#/lessons/block-scope-let , for example)

This fix just simply logs the error to both the console and the display, making it easier for users to discern whats going on.